### PR TITLE
Code & XML

### DIFF
--- a/.idea/deviceManager.xml
+++ b/.idea/deviceManager.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DeviceTable">
+    <option name="columnSorters">
+      <list>
+        <ColumnSorterState>
+          <option name="column" value="Name" />
+          <option name="order" value="ASCENDING" />
+        </ColumnSorterState>
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ Part A: Build a Catalogue App
 # Group Information
 Student IDs: 
     22223850,
-    XXXXXXXX
+    21355176
 Student Names: 
     Amanda Huyen Nguyen,
-    X X X
+    Raunak Arora
 
 # Design Content
 Theme: Restaurants in Perth -

--- a/app/src/main/java/com/example/assignment1/CatalogAdapter.kt
+++ b/app/src/main/java/com/example/assignment1/CatalogAdapter.kt
@@ -11,6 +11,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
+import android.widget.ImageButton
 import android.widget.TextView
 import androidx.annotation.LayoutRes
 import androidx.recyclerview.widget.DiffUtil
@@ -19,6 +20,8 @@ import androidx.recyclerview.widget.RecyclerView
 
 class CatalogAdapter(
     private val onItemClick: (CatalogItem) -> Unit,
+    private val isFavourite: (CatalogItem) -> Boolean,
+    private val onToggleFavourite: (CatalogItem) -> Unit,
     isGridInitial: Boolean = true
 ) : ListAdapter<CatalogItem, CatalogAdapter.VH>(DIFF) {
 
@@ -34,32 +37,48 @@ class CatalogAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, @LayoutRes viewType: Int): VH {
         val view = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
-        return VH(view, onItemClick)
+        return VH(view, onItemClick, isFavourite, onToggleFavourite)
     }
 
     override fun onBindViewHolder(holder: VH, position: Int) = holder.bind(getItem(position))
 
-    class VH(itemView: View, private val onClick: (CatalogItem) -> Unit) :
-            RecyclerView.ViewHolder(itemView) {
+    class VH(
+        itemView: View,
+        private val onClick: (CatalogItem) -> Unit,
+        private val isFav: (CatalogItem) -> Boolean,
+        private val onToggleFav: (CatalogItem) -> Unit
+    ) : RecyclerView.ViewHolder(itemView) {
             private val iv: ImageView = itemView.findViewById(R.id.iv)
             private val tvTitle: TextView = itemView.findViewById(R.id.tvTitle)
             private val tvDesc: TextView = itemView.findViewById(R.id.tvDesc)
             private val chip: TextView = itemView.findViewById(R.id.chipCategory)
+            private val btnFav: ImageButton? = itemView.findViewById(R.id.btnFav)
 
-        fun bind(item: CatalogItem) {
-            tvTitle.text = item.title
-            tvDesc.text = item.description
-            chip.text = item.category.displayName
+            fun bind(item: CatalogItem) {
+                tvTitle.text = item.title
+                tvDesc.text = item.description
+                chip.text = item.category.displayName
 
-            // Resolve drawable by name, falls back to placeholder
-            val resId = itemView.resources.getIdentifier(
-                item.imageName,
-                "drawable",
-                itemView.context.packageName
-            )
-            iv.setImageResource(if (resId != 0) resId else R.drawable.placeholder)
+                // Resolve drawable by name, falls back to placeholder
+                val resId = itemView.resources.getIdentifier(
+                    item.imageName,
+                    "drawable",
+                    itemView.context.packageName
+                )
+                iv.setImageResource(if (resId != 0) resId else R.drawable.placeholder)
 
-            itemView.setOnClickListener { onClick(item) }
+                // Row click -> detail
+                itemView.setOnClickListener { onClick(item) }
+
+                // Heart icon -> reflects current fav state, toggles on press
+                btnFav?.apply {
+                    setImageResource(if (isFav(item)) R.drawable.ic_favorite_24 else R.drawable.ic_favorite_border_24)
+                    setOnClickListener {
+                        onToggleFav(item)
+                        //update the icon immediately
+                        setImageResource(if (isFav(item)) R.drawable.ic_favorite_24 else R.drawable.ic_favorite_border_24)
+                    }
+                }
         }
     }
 

--- a/app/src/main/java/com/example/assignment1/ListFragment.kt
+++ b/app/src/main/java/com/example/assignment1/ListFragment.kt
@@ -11,11 +11,8 @@ package com.example.assignment1
 import android.content.res.Configuration
 import android.os.Bundle
 import android.view.View
-import android.widget.Button
 import android.widget.CompoundButton
-import android.widget.Toast
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -26,18 +23,26 @@ import com.google.android.material.button.MaterialButton
 import com.google.android.material.materialswitch.MaterialSwitch
 import kotlinx.coroutines.launch
 import androidx.core.widget.addTextChangedListener
+import androidx.fragment.app.activityViewModels
+import androidx.transition.AutoTransition
+import androidx.transition.TransitionManager
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
+import android.content.Context
 
 // Fragment that shows the catalog list, category chips, and the grid/list toggle
 class ListFragment : Fragment(R.layout.fragment_list) {
 
-    // Attach a ViewModel scoped to this fragment
-    private val vm: CatalogViewModel by viewModels()
+    // ACTIVITY-Scoped VM so favourites & filters are shared with DetailFragments
+    private val vm: CatalogViewModel by activityViewModels()
 
     // References to UI widgets
     private lateinit var rv: RecyclerView
     private lateinit var switchLayout: MaterialSwitch
 
     // Category buttons
+    private lateinit var btnFavourites: MaterialButton
     private lateinit var btnAll: MaterialButton
     private lateinit var btnVietnamese: MaterialButton
     private lateinit var btnItalian: MaterialButton
@@ -47,15 +52,9 @@ class ListFragment : Fragment(R.layout.fragment_list) {
     private lateinit var btnIndian: MaterialButton
 
     // Navigation to detail
-    private val adapter = CatalogAdapter(
-        onItemClick = { item ->
-            parentFragmentManager.beginTransaction()
-                .replace(R.id.container, DetailFragment.newInstance(item))
-                .addToBackStack("detail")
-                .commit()
-        },
-        isGridInitial = true    // Default mode is Grid
-    )
+    private lateinit var adapter: CatalogAdapter
+
+
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -64,6 +63,18 @@ class ListFragment : Fragment(R.layout.fragment_list) {
         rv = view.findViewById(R.id.rv)
         switchLayout = view.findViewById(R.id.switchLayout)
 
+        val header = view.findViewById<View>(R.id.header)
+        val headerInitialTop = header.paddingTop
+        val rvInitialBottom = rv.paddingBottom
+
+        ViewCompat.setOnApplyWindowInsetsListener(view){_, insets ->
+            val sysBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            header.updatePadding(top = headerInitialTop + sysBars.top)
+            rv.updatePadding(bottom = rvInitialBottom + sysBars.bottom)
+            insets
+        }
+        ViewCompat.requestApplyInsets(view)
+
         // Find search box
         val etSearch = view.findViewById<com.google.android.material.textfield.TextInputEditText>(R.id.etSearch)
         etSearch.addTextChangedListener { text ->
@@ -71,6 +82,7 @@ class ListFragment : Fragment(R.layout.fragment_list) {
         }
 
         // find category Buttons
+        btnFavourites = view.findViewById(R.id.btnFavourites)
         btnAll = view.findViewById(R.id.btnAll)
         btnVietnamese = view.findViewById(R.id.btnVietnamese)
         btnItalian = view.findViewById(R.id.btnItalian)
@@ -80,24 +92,45 @@ class ListFragment : Fragment(R.layout.fragment_list) {
         btnIndian = view.findViewById(R.id.btnIndian)
 
         // Make buttons toggleable to show a "selected" state
-        makeCheckable(btnAll, btnVietnamese, btnIndian, btnJapanese, btnChinese, btnThai, btnIndian)
+        makeCheckable(btnFavourites, btnAll, btnVietnamese, btnItalian, btnJapanese, btnChinese, btnThai, btnIndian)
 
         // Button click listeners
-        btnAll.setOnClickListener { vm.setCategory(null) }
-        btnVietnamese.setOnClickListener { vm.setCategory(Category.VIETNAMESE) }
-        btnItalian.setOnClickListener { vm.setCategory(Category.ITALIAN) }
-        btnJapanese.setOnClickListener {vm.setCategory(Category.JAPANESE) }
-        btnChinese.setOnClickListener { vm.setCategory(Category.CHINESE) }
-        btnThai.setOnClickListener { vm.setCategory(Category.THAI) }
-        btnIndian.setOnClickListener { vm.setCategory(Category.INDIAN) }
+        btnFavourites.setOnClickListener {
+            vm.toggleFavouritesOnly()
+            // When Favourites is ON, de-select category filter
+        }
+        btnAll.setOnClickListener {
+            vm.setFavouritesOnly(false)
+            vm.setCategory(null)
+        }
 
+        btnVietnamese.setOnClickListener { vm.setFavouritesOnly(false); vm.setCategory(Category.VIETNAMESE) }
+        btnItalian.setOnClickListener { vm.setFavouritesOnly(false); vm.setCategory(Category.ITALIAN) }
+        btnJapanese.setOnClickListener {vm.setFavouritesOnly(false); vm.setCategory(Category.JAPANESE) }
+        btnChinese.setOnClickListener { vm.setFavouritesOnly(false); vm.setCategory(Category.CHINESE) }
+        btnThai.setOnClickListener { vm.setFavouritesOnly(false); vm.setCategory(Category.THAI) }
+        btnIndian.setOnClickListener { vm.setFavouritesOnly(false); vm.setCategory(Category.INDIAN) }
+
+        // Adapter
+        adapter = CatalogAdapter(
+            onItemClick = { item ->
+                parentFragmentManager.beginTransaction()
+                    .replace(R.id.container, DetailFragment.newInstance(item))
+                    .addToBackStack("detail")
+                    .commit()
+            },
+            isFavourite = vm::isFavourite,
+            onToggleFavourite = vm::toggleFavourite,
+            isGridInitial = true
+        )
         // Set up RecyclerView & switchLayout setup
         rv.adapter = adapter
         bindLayoutManager(isGrid = true)    // Start in Grid layout
 
         // Switch: Grid/List
-        switchLayout.setOnCheckedChangeListener { _: CompoundButton, _: Boolean ->
-            vm.toggleLayout()   // State drives the actual binding below
+        switchLayout.setOnCheckedChangeListener { _: CompoundButton, isChecked: Boolean ->
+            TransitionManager.beginDelayedTransition(rv, AutoTransition())
+            vm.setLayout(isChecked)
         }
 
         // Collect state from ViewModel
@@ -109,7 +142,10 @@ class ListFragment : Fragment(R.layout.fragment_list) {
                 launch {
                     vm.isGrid.collect { isGrid ->
                         // Update switch state
-                        switchLayout.isChecked = isGrid     // keep UI in sync
+                        if (switchLayout.isChecked != isGrid)
+                        {
+                            switchLayout.isChecked = isGrid
+                        }
                         // Tell adapter which layout to use
                         adapter.isGridMode = isGrid
                         // Update the RecyclerView LayoutManager
@@ -128,40 +164,46 @@ class ListFragment : Fragment(R.layout.fragment_list) {
                 // Selected category -> reflect on button checked states
                 launch {
                     vm.selectedCategory.collect { cat ->
-                        updateButtonChecks(cat)
+                        updateButtonChecks(cat, vm.favouritesOnly.value)
+                    }
+                }
+
+                launch {
+                    vm.favouritesOnly.collect { favOnly ->
+                        updateButtonChecks(vm.selectedCategory.value, favOnly)
                     }
                 }
             }
         }
+        val prefs = requireContext().getSharedPreferences("catalog_prefs", Context.MODE_PRIVATE)
+        val saved = prefs.getStringSet("favourites", emptySet()) ?: emptySet()
+        vm.setFavourites(saved)
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED){
+                launch {
+                    vm.favourites.collect { set ->
+                        prefs.edit().putStringSet("favourites", set).apply()
+                    }
+                }
+            }
+        }
+
     }
 
-    // Toggle a category; ensures single selection and updates ViewModel
-    private fun selectCategory(cat: Category?) {
-        vm.setCategory(cat)
-        updateButtonChecks(cat)     // immediate visual feedback
-    }
 
     // Keep only the chosen button "checked" (green); others unchecked (blue)
-    private fun updateButtonChecks(cat: Category?) {
+    private fun updateButtonChecks(cat: Category?, favOnly: Boolean) {
+        setChecked(btnFavourites, favOnly)
         // Reset all to unchecked first
-        setChecked(btnAll, false)
-        setChecked(btnVietnamese, false)
-        setChecked(btnItalian, false)
-        setChecked(btnJapanese, false)
-        setChecked(btnChinese, false)
-        setChecked(btnThai, false)
-        setChecked(btnIndian, false)
+        setChecked(btnAll, !favOnly && cat == null)
+        setChecked(btnVietnamese, !favOnly && cat == Category.VIETNAMESE)
+        setChecked(btnItalian, !favOnly && cat == Category.ITALIAN)
+        setChecked(btnJapanese, !favOnly && cat == Category.JAPANESE)
+        setChecked(btnChinese, !favOnly && cat == Category.CHINESE)
+        setChecked(btnThai, !favOnly && cat == Category.THAI)
+        setChecked(btnIndian, !favOnly && cat == Category.INDIAN)
 
-        // Turn on just the active one
-        when (cat) {
-            null -> setChecked(btnAll, true)
-            Category.VIETNAMESE -> setChecked(btnVietnamese, true)
-            Category.ITALIAN -> setChecked(btnItalian, true)
-            Category.JAPANESE -> setChecked(btnJapanese, true)
-            Category.CHINESE -> setChecked(btnChinese, true)
-            Category.THAI -> setChecked(btnThai, true)
-            Category.INDIAN -> setChecked(btnIndian, true)
-        }
     }
 
     private fun setChecked(btn: MaterialButton, checked: Boolean) {
@@ -176,14 +218,59 @@ class ListFragment : Fragment(R.layout.fragment_list) {
 
     // Switch between GridLayoutManager and LinearLayoutManager
     private fun bindLayoutManager(isGrid: Boolean) {
-        if (!isGrid) {
-            // LinearLayoutManager -> vertical list
+        if(!isGrid)
+        {
             rv.layoutManager = LinearLayoutManager(requireContext())
             return
         }
-        // GridLayoutManager with span count depending on screen/orientation
-        val span = calculateSpanCount()
-        rv.layoutManager = GridLayoutManager(requireContext(), span)
+
+        // Initial span based on current width
+        val initialSpan = computeSpanByWidthPx(rv.width)
+        val glm = GridLayoutManager(requireContext(), if (initialSpan > 0) initialSpan else calculateSpanFallback())
+        rv.layoutManager = glm
+
+        // Recompute span when the RecyclerView's size changes (rotation, split screen, etc)
+        rv.addOnLayoutChangeListener(object: View.OnLayoutChangeListener {
+            override fun onLayoutChange(
+                v: View?,
+                left: Int,
+                top: Int,
+                right: Int,
+                bottom: Int,
+                oldLeft: Int,
+                oldTop: Int,
+                oldRight: Int,
+                oldBottom: Int
+            ) {
+                if (!vm.isGrid.value) return
+                val newSpan = computeSpanByWidthPx(rv.width)
+                val manager = rv.layoutManager as? GridLayoutManager?: return
+                if(newSpan > 0 && manager.spanCount != newSpan)
+                {
+                    manager.spanCount = newSpan
+                }
+            }
+        })
+    }
+
+    // Compute columns by actual px width so it adapts in split-screen
+    private fun computeSpanByWidthPx(rvWidthPx: Int): Int {
+        if (rvWidthPx <= 0)
+        {
+            return 0
+        }
+        val dm = resources.displayMetrics
+        val density = dm.density
+        val minCellDp = 168f // target minimum card width
+        val minCellPx = (minCellDp * density)
+        val available = (rvWidthPx - rv.paddingLeft - rv.paddingRight).coerceAtLeast(0)
+        return (available /  minCellPx).toInt().coerceAtLeast(1)
+    }
+
+    private fun calculateSpanFallback(): Int {
+        val widthDp = resources.configuration.screenWidthDp.takeIf { it > 0 } ?: 360
+        val minCellDp = 168f
+        return (widthDp / minCellDp).toInt().coerceAtLeast(1)
     }
 
     // Calculate how many columns Grid should have

--- a/app/src/main/java/com/example/assignment1/MainActivity.kt
+++ b/app/src/main/java/com/example/assignment1/MainActivity.kt
@@ -2,11 +2,13 @@ package com.example.assignment1
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.WindowCompat
 import androidx.fragment.app.commit
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
         setContentView(R.layout.activity_main)
 
         if (savedInstanceState == null) {

--- a/app/src/main/res/drawable/ic_favorite_24.xml
+++ b/app/src/main/res/drawable/ic_favorite_24.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,21.35l-1.45,-1.32C5.4,15.36 2,12.28 2,8.5 2,5.42 4.42,3 7.5,3c1.74,0 3.41,0.81 4.5,2.09C13.09,3.81 14.76,3 16.5,3 19.58,3 22,5.42 22,8.5c0,3.78 -3.4,6.86 -8.55,11.54L12,21.35z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_favorite_border_24.xml
+++ b/app/src/main/res/drawable/ic_favorite_border_24.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp" android:height="24dp"
+    android:viewportWidth="24" android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M16.5,3c-1.74,0 -3.41,0.81 -4.5,2.09C10.91,3.81 9.24,3 7.5,3 4.42,3 2,5.42 2,8.5c0,3.78 3.4,6.86 8.55,11.54L12,21.35l1.45,-1.32C18.6,15.36 22,12.28 22,8.5 22,5.42 19.58,3 16.5,3zM12.1,18.55l-0.1,0.1 -0.1,-0.1C7.14,14.24 4,11.39 4,8.5 4,6.5 5.5,5 7.5,5c1.54,0 3.04,1 3.57,2.36h1.87C13.46,6 14.96,5 16.5,5 18.5,5 20,6.5 20,8.5c0,2.89 -3.14,5.74 -7.9,10.05z"/>
+</vector>

--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -11,10 +11,12 @@
 -->
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/scroll"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <LinearLayout
+        android:id="@+id/detailContent"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
@@ -45,6 +47,30 @@
             android:clickable="false"
             android:focusable="false"
             android:text="Category"/>
+
+        <!-- Actions: Close + Favourite -->
+        <LinearLayout
+            android:id="@+id/actionRow"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:orientation="horizontal">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnClose"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:minHeight="48dp"
+                android:text="@string/action_close" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnFavToggle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:minHeight="48dp"
+                android:layout_marginStart="8dp"
+                android:text="@string/action_add_favourite" />
+        </LinearLayout>
 
         <TextView
             android:id="@+id/tvDesc"

--- a/app/src/main/res/layout/fragment_list.xml
+++ b/app/src/main/res/layout/fragment_list.xml
@@ -46,6 +46,11 @@
                 android:id="@+id/switchLayout"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:minHeight="48dp"
+                android:maxHeight="72dp"
+                android:padding="8dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginEnd="8dp"
                 android:text="@string/switch_grid"
                 android:checked="true"/>
 
@@ -83,6 +88,13 @@
             android:layout_height="wrap_content"
             android:orientation="horizontal"
             android:gravity="center_vertical">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnFavourites"
+                style="@style/Widget.Catalog.FilterButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/filter_favourites"/>
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnAll"

--- a/app/src/main/res/layout/item_catalog_grid.xml
+++ b/app/src/main/res/layout/item_catalog_grid.xml
@@ -65,4 +65,16 @@
         app:layout_constraintTop_toBottomOf="@id/tvDesc"
         app:layout_constraintStart_toStartOf="@id/tvDesc" />
 
+    <ImageButton
+        android:id="@+id/btnFav"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/cd_favourite"
+        android:padding="6dp"
+        android:tint="?attr/colorPrimary"
+        app:layout_constraintTop_toTopOf="@id/tvTitle"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:srcCompat="@drawable/ic_favorite_border_24" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_catalog_list.xml
+++ b/app/src/main/res/layout/item_catalog_list.xml
@@ -66,4 +66,16 @@
         app:layout_constraintStart_toStartOf="@id/tvDesc"
         app:layout_constraintTop_toBottomOf="@id/tvDesc" />
 
+    <ImageButton
+        android:id="@+id/btnFav"
+        android:layout_width="36dp"
+        android:layout_height="36dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="@string/cd_favourite"
+        android:padding="6dp"
+        android:tint="?attr/colorPrimary"
+        app:layout_constraintTop_toTopOf="@id/tvTitle"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:srcCompat="@drawable/ic_favorite_border_24" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,5 +12,13 @@
     <string name="cat_thai">Thai</string>
     <string name="cat_indian">Indian</string>
 
+    <!-- Favourites & detail actions -->
+    <string name="filter_favourites">Favourites</string>
+    <string name="cd_favourite">Toggle favourite</string>
+    <string name="action_close">Close</string>
+    <string name="action_add_favourite">Add to Favourites</string>
+    <string name="action_remove_favourite">Remove Favourite</string>
+    <string name="action_open_maps">Open in Maps</string>
+
     <string name="search_hint">Search restaurants...</string>
 </resources>


### PR DESCRIPTION
--------------------------------------------------------------------------------------------------- MainActivity.kt
- Opted into edge-to-edge
- No logic change, still launches ListFragment.kt

CatalogViewModel.kt
- Added favourites state
- Added favourites-only filter
- Combined filters (category + query + favouritesOnly)
- Layout control: explicit setter for grid/list

CatalogAdapter.kt
- Adapter no accepts isFavourite and onToggleFavourite lambdas.
- Added heart button handling to show filled/outline and toggle without affecting row click
- Supports both grid and list item layouts via getItemViewType.

ListFragment.kt
- Uses activityViewModels() so state (filters, favourites) is shared with DetailFragment.kt
- Search box hooked to vm.setQuery()
- Category buttons + new Favourites button wired.
- Fixed grid/list switch feedback loop: listener calls vm.setLayout(isChecked), collector guards switch.isChecked.
- Adaptive grid columns: compute span from actual width and update on layout changes (works on tablets & split-screen).
- Safe-area handling: applies system bar/cutout insets to header and RecyclerView padding so nothing sits under the camera hole/gesture bar

fragment_list.xml
- Moved btnFavourites inside the LinearLayout within HorizontalScrollView
- Material switch tap-target improved (minHeight, minWidth, padding, margins).
- Contains search field, header, category buttons, and Recycler View.

item_catalog_grid.xml
- Added ImageButton @id/btnFav (top-right over image) with app:srcCompat and tint.
- Card still shows image, title, desc and category chip.

item_catalog_list.xml
- Added ImageButton @id/btnFav on the right side of the row.
- Row remains: image left, text right, category chip.

fragment_detail.xml
- Structured as ScrollView → LinearLayout @id/detailContent.
- Added Close (@id/btnClose) and Favourite toggle (@id/btnFavToggle) action buttons.
- Kept large image, title, category badge, description.
- Stable IDs for safe-area padding (@id/scroll, @id/detailContent).

DetailFragment.kt
- Reads args (title, desc, category, image).
- Safe-area handling: applies system bar/cutout insets to detailContent padding so content doesn’t sit under camera bump.
- Close action pops back stack.
- Favourite toggle reflects and updates ViewModel state (button text changes between Add/Remove Favourite).
- Uses placeholder if image resource not found. --------------------------------------------------------------------------------

Resources & Assets
strings.xml
- Added: filter_favourites, cd_favourite, action_close, action_add_favourite, action_remove_favourite, (kept existing catalog/switch/search strings)

Drawable vectors
-Added: ic_favorite_24.xml and ic_favorite_border_24.xml (Material heart filled/outline).